### PR TITLE
Step6: Add Unit and E2E Tests for Item Listing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following icons indicate pointers for
 - [x] **STEP4** Develop API ([JA](document/04-api.ja.md)
   /[EN](document/04-api.en.md))
 - [x] **STEP5** Database ([JA](document/05-database.ja.md)/[EN](document/05-database.en.md))
-- [ ] **STEP6** Writing Tests ([JA](document/06-testing.ja.md)/[EN](document/06-testing.en.md))
+- [x] **STEP6** Writing Tests ([JA](document/06-testing.ja.md)/[EN](document/06-testing.en.md))
 - [x] **STEP7** Docker ([JA](document/07-docker.ja.md)/[EN](document/07-docker.en.md))
 - [x] **STEP8** Continuous Integration(CI) ([JA](document/08-ci.ja.md)
   /[EN](document/08-ci.en.md))

--- a/go/app/infra.go
+++ b/go/app/infra.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 
-	// STEP 5-1: uncomment this line
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -22,7 +21,7 @@ type Item struct {
 	Name       string `db:"name" json:"name"`
 	Category   string `db:"category" json:"category"`
 	CategoryID int    `db:"category_id" json:"-"`
-	ImageName  string `db:"image_name" json:"image_name"` // STEP 4-4: add an image field
+	ImageName  string `db:"image_name" json:"image_name"`
 }
 
 type Category struct {
@@ -30,9 +29,6 @@ type Category struct {
 	Name string `db:"name" json:"name"`
 }
 
-// Please run `go generate ./...` to generate the mock implementation
-// ItemRepository is an interface to manage items.
-//
 //go:generate go run go.uber.org/mock/mockgen -source=$GOFILE -package=${GOPACKAGE} -destination=./mock_$GOFILE
 type ItemRepository interface {
 	Insert(ctx context.Context, item *Item) error
@@ -41,25 +37,25 @@ type ItemRepository interface {
 	SearchByKeyword(ctx context.Context, keyword string) ([]*Item, error)
 }
 
-// CategoryRepository is an interface to manage categories.
 type CategoryRepository interface {
 	GetOrCreate(ctx context.Context, name string) (int, error)
 	GetByID(ctx context.Context, id int) (*Category, error)
 }
 
-// itemRepository is an implementation of ItemRepository
 type itemRepository struct {
 	db *sql.DB
 }
 
-// categoryRepository is an implementation of CategoryRepository
 type categoryRepository struct {
 	db *sql.DB
 }
 
-// NewItemRepository creates a new itemRepository.
 func NewItemRepository(db *sql.DB) ItemRepository {
 	return &itemRepository{db: db}
+}
+
+func NewCategoryRepository(db *sql.DB) CategoryRepository {
+	return &categoryRepository{db: db}
 }
 
 // Insert inserts an item into the repository.
@@ -76,51 +72,6 @@ func (i *itemRepository) Insert(ctx context.Context, item *Item) error {
 	return nil
 }
 
-// NewCategoryRepository creates a new categoryRepository.
-func NewCategoryRepository(db *sql.DB) CategoryRepository {
-	return &categoryRepository{db: db}
-}
-
-// GetOrCreate gets a category by name or creates a new one if it doesn't exist.
-func (c *categoryRepository) GetOrCreate(ctx context.Context, name string) (int, error) {
-	var id int
-	query := `SELECT id FROM categories WHERE name = ?`
-	err := c.db.QueryRowContext(ctx, query, name).Scan(&id)
-	if err == nil {
-		return id, nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return 0, fmt.Errorf("failed to query category: %w", err)
-	}
-
-	result, err := c.db.ExecContext(ctx, `INSERT INTO categories (name) VALUES (?)`, name)
-	if err != nil {
-		return 0, fmt.Errorf("failed to insert category: %w", err)
-	}
-
-	lastID, err := result.LastInsertId()
-	if err != nil {
-		return 0, fmt.Errorf("failed to get last insert id: %w", err)
-	}
-
-	return int(lastID), nil
-}
-
-// GetByID gets a category by id.
-func (c *categoryRepository) GetByID(ctx context.Context, id int) (*Category, error) {
-	var category Category
-	query := `SELECT id, name FROM categories WHERE id = ?`
-	err := c.db.QueryRowContext(ctx, query, id).Scan(&category.ID, &category.Name)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errCategoryNotFound
-		}
-		return nil, fmt.Errorf("failed to scan category: %w", err)
-	}
-	return &category, nil
-}
-
-// List list items from the repository
 func (i *itemRepository) List(ctx context.Context) ([]*Item, error) {
 	const query = `
         SELECT i.id, i.name, i.category_id, c.name as category_name, i.image_name 
@@ -149,7 +100,7 @@ func (i *itemRepository) List(ctx context.Context) ([]*Item, error) {
 	return items, nil
 }
 
-// Select gets item from repository by id
+// Select retrieves an item by id.
 func (i *itemRepository) Select(ctx context.Context, id int) (*Item, error) {
 	const query = `
         SELECT i.id, i.name, i.category_id, c.name as category_name, i.image_name 
@@ -171,18 +122,7 @@ func (i *itemRepository) Select(ctx context.Context, id int) (*Item, error) {
 	return &it, nil
 }
 
-// StoreImage stores an image and returns an error if any.
-// This package doesn't have a related interface for simplicity.
-func StoreImage(fileName string, image []byte) error {
-	// STEP 4-4: add an implementation to store an image
-	if err := os.WriteFile(fileName, image, 0644); err != nil {
-		return fmt.Errorf("failed to write image file: %w", err)
-	}
-
-	return nil
-}
-
-// SearchByKeyword searches items that contain the specified keyword in their name
+// SearchByKeyword searches items containing the keyword.
 func (i *itemRepository) SearchByKeyword(ctx context.Context, keyword string) ([]*Item, error) {
 	const query = `
         SELECT i.id, i.name, i.category_id, c.name as category_name, i.image_name 
@@ -212,4 +152,50 @@ func (i *itemRepository) SearchByKeyword(ctx context.Context, keyword string) ([
 		return nil, fmt.Errorf("row error: %w", err)
 	}
 	return items, nil
+}
+
+func (c *categoryRepository) GetOrCreate(ctx context.Context, name string) (int, error) {
+	var id int
+	query := `SELECT id FROM categories WHERE name = ?`
+	err := c.db.QueryRowContext(ctx, query, name).Scan(&id)
+	if err == nil {
+		return id, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf("failed to query category: %w", err)
+	}
+
+	result, err := c.db.ExecContext(ctx, `INSERT INTO categories (name) VALUES (?)`, name)
+	if err != nil {
+		return 0, fmt.Errorf("failed to insert category: %w", err)
+	}
+
+	lastID, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get last insert id: %w", err)
+	}
+
+	return int(lastID), nil
+}
+
+// GetByID retrieves a category by id.
+func (c *categoryRepository) GetByID(ctx context.Context, id int) (*Category, error) {
+	var category Category
+	query := `SELECT id, name FROM categories WHERE id = ?`
+	err := c.db.QueryRowContext(ctx, query, id).Scan(&category.ID, &category.Name)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errCategoryNotFound
+		}
+		return nil, fmt.Errorf("failed to scan category: %w", err)
+	}
+	return &category, nil
+}
+
+// StoreImage stores an image file.
+func StoreImage(fileName string, image []byte) error {
+	if err := os.WriteFile(fileName, image, 0644); err != nil {
+		return fmt.Errorf("failed to write image file: %w", err)
+	}
+	return nil
 }

--- a/go/app/mock_infra.go
+++ b/go/app/mock_infra.go
@@ -53,3 +53,102 @@ func (mr *MockItemRepositoryMockRecorder) Insert(ctx, item any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Insert", reflect.TypeOf((*MockItemRepository)(nil).Insert), ctx, item)
 }
+
+// List mocks base method.
+func (m *MockItemRepository) List(ctx context.Context) ([]*Item, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", ctx)
+	ret0, _ := ret[0].([]*Item)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockItemRepositoryMockRecorder) List(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockItemRepository)(nil).List), ctx)
+}
+
+// SearchByKeyword mocks base method.
+func (m *MockItemRepository) SearchByKeyword(ctx context.Context, keyword string) ([]*Item, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchByKeyword", ctx, keyword)
+	ret0, _ := ret[0].([]*Item)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchByKeyword indicates an expected call of SearchByKeyword.
+func (mr *MockItemRepositoryMockRecorder) SearchByKeyword(ctx, keyword any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchByKeyword", reflect.TypeOf((*MockItemRepository)(nil).SearchByKeyword), ctx, keyword)
+}
+
+// Select mocks base method.
+func (m *MockItemRepository) Select(ctx context.Context, id int) (*Item, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Select", ctx, id)
+	ret0, _ := ret[0].(*Item)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Select indicates an expected call of Select.
+func (mr *MockItemRepositoryMockRecorder) Select(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Select", reflect.TypeOf((*MockItemRepository)(nil).Select), ctx, id)
+}
+
+// MockCategoryRepository is a mock of CategoryRepository interface.
+type MockCategoryRepository struct {
+	ctrl     *gomock.Controller
+	recorder *MockCategoryRepositoryMockRecorder
+	isgomock struct{}
+}
+
+// MockCategoryRepositoryMockRecorder is the mock recorder for MockCategoryRepository.
+type MockCategoryRepositoryMockRecorder struct {
+	mock *MockCategoryRepository
+}
+
+// NewMockCategoryRepository creates a new mock instance.
+func NewMockCategoryRepository(ctrl *gomock.Controller) *MockCategoryRepository {
+	mock := &MockCategoryRepository{ctrl: ctrl}
+	mock.recorder = &MockCategoryRepositoryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCategoryRepository) EXPECT() *MockCategoryRepositoryMockRecorder {
+	return m.recorder
+}
+
+// GetByID mocks base method.
+func (m *MockCategoryRepository) GetByID(ctx context.Context, id int) (*Category, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByID", ctx, id)
+	ret0, _ := ret[0].(*Category)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByID indicates an expected call of GetByID.
+func (mr *MockCategoryRepositoryMockRecorder) GetByID(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByID", reflect.TypeOf((*MockCategoryRepository)(nil).GetByID), ctx, id)
+}
+
+// GetOrCreate mocks base method.
+func (m *MockCategoryRepository) GetOrCreate(ctx context.Context, name string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrCreate", ctx, name)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrCreate indicates an expected call of GetOrCreate.
+func (mr *MockCategoryRepositoryMockRecorder) GetOrCreate(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreate", reflect.TypeOf((*MockCategoryRepository)(nil).GetOrCreate), ctx, name)
+}

--- a/go/app/server_test.go
+++ b/go/app/server_test.go
@@ -1,14 +1,18 @@
 package app
 
 import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	gomock "go.uber.org/mock/gomock"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"strings"
+	"os"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
-	"go.uber.org/mock/gomock"
 )
 
 func TestParseAddItemRequest(t *testing.T) {
@@ -19,20 +23,21 @@ func TestParseAddItemRequest(t *testing.T) {
 		err bool
 	}
 
-	// STEP 6-1: define test cases
 	cases := map[string]struct {
 		args map[string]string
 		wants
 	}{
 		"ok: valid request": {
 			args: map[string]string{
-				"name":     "", // fill here
-				"category": "", // fill here
+				"name":     "jacket",
+				"category": "fashion",
+				"image":    "images/local_image.jpg",
 			},
 			wants: wants{
 				req: &AddItemRequest{
-					Name: "", // fill here
-					// Category: "", // fill here
+					Name:     "jacket",
+					Category: "fashion",
+					Image:    []byte("images/local_image.jpg"),
 				},
 				err: false,
 			},
@@ -50,23 +55,32 @@ func TestParseAddItemRequest(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// prepare request body
-			values := url.Values{}
+			var b bytes.Buffer
+			w := multipart.NewWriter(&b)
+
 			for k, v := range tt.args {
-				values.Set(k, v)
+				if k == "image" {
+					fw, err := w.CreateFormFile("image", v)
+					if err != nil {
+						t.Fatal(err)
+					}
+					fw.Write([]byte(v))
+				} else {
+					if err := w.WriteField(k, v); err != nil {
+						t.Fatal(err)
+					}
+				}
 			}
+			w.Close()
 
-			// prepare HTTP request
-			req, err := http.NewRequest("POST", "http://localhost:9001/items", strings.NewReader(values.Encode()))
+			req, err := http.NewRequest("POST", "/items", &b)
 			if err != nil {
-				t.Fatalf("failed to create request: %v", err)
+				t.Fatal(err)
 			}
-			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("Content-Type", w.FormDataContentType())
 
-			// execute test target
 			got, err := parseAddItemRequest(req)
 
-			// confirm the result
 			if err != nil {
 				if !tt.err {
 					t.Errorf("unexpected error: %v", err)
@@ -83,48 +97,56 @@ func TestParseAddItemRequest(t *testing.T) {
 func TestHelloHandler(t *testing.T) {
 	t.Parallel()
 
-	// Please comment out for STEP 6-2
-	// predefine what we want
-	// type wants struct {
-	// 	code int               // desired HTTP status code
-	// 	body map[string]string // desired body
-	// }
-	// want := wants{
-	// 	code: http.StatusOK,
-	// 	body: map[string]string{"message": "Hello, world!"},
-	// }
+	want := struct {
+		code int
+		body map[string]string
+	}{
+		code: http.StatusOK,
+		body: map[string]string{"message": "Hello, world!"},
+	}
 
-	// set up test
 	req := httptest.NewRequest("GET", "/hello", nil)
 	res := httptest.NewRecorder()
 
 	h := &Handlers{}
 	h.Hello(res, req)
 
-	// STEP 6-2: confirm the status code
+	if res.Code != want.code {
+		t.Errorf("expected status code %d, got %d", want.code, res.Code)
+	}
 
-	// STEP 6-2: confirm response body
+	var got map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+
+	if diff := cmp.Diff(want.body, got); diff != "" {
+		t.Errorf("unexpected response body (-want +got):\n%s", diff)
+	}
 }
 
 func TestAddItem(t *testing.T) {
 	t.Parallel()
+
+	tmpDir := t.TempDir()
 
 	type wants struct {
 		code int
 	}
 	cases := map[string]struct {
 		args     map[string]string
-		injector func(m *MockItemRepository)
+		injector func(m *MockItemRepository, c *MockCategoryRepository)
 		wants
 	}{
 		"ok: correctly inserted": {
 			args: map[string]string{
 				"name":     "used iPhone 16e",
 				"category": "phone",
+				"image":    "test.jpg",
 			},
-			injector: func(m *MockItemRepository) {
-				// STEP 6-3: define mock expectation
-				// succeeded to insert
+			injector: func(m *MockItemRepository, c *MockCategoryRepository) {
+				c.EXPECT().GetOrCreate(gomock.Any(), gomock.Any()).Return(1, nil)
+				m.EXPECT().Insert(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			wants: wants{
 				code: http.StatusOK,
@@ -134,10 +156,11 @@ func TestAddItem(t *testing.T) {
 			args: map[string]string{
 				"name":     "used iPhone 16e",
 				"category": "phone",
+				"image":    "test.jpg",
 			},
-			injector: func(m *MockItemRepository) {
-				// STEP 6-3: define mock expectation
-				// failed to insert
+			injector: func(m *MockItemRepository, c *MockCategoryRepository) {
+				c.EXPECT().GetOrCreate(gomock.Any(), gomock.Any()).Return(1, nil)
+				m.EXPECT().Insert(gomock.Any(), gomock.Any()).Return(errors.New("failed to insert"))
 			},
 			wants: wants{
 				code: http.StatusInternalServerError,
@@ -150,17 +173,36 @@ func TestAddItem(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)
-
 			mockIR := NewMockItemRepository(ctrl)
-			tt.injector(mockIR)
-			h := &Handlers{itemRepo: mockIR}
+			mockCR := NewMockCategoryRepository(ctrl)
+			tt.injector(mockIR, mockCR)
 
-			values := url.Values{}
-			for k, v := range tt.args {
-				values.Set(k, v)
+			h := &Handlers{
+				imgDirPath:   tmpDir,
+				itemRepo:     mockIR,
+				categoryRepo: mockCR,
 			}
-			req := httptest.NewRequest("POST", "/items", strings.NewReader(values.Encode()))
-			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			var b bytes.Buffer
+			w := multipart.NewWriter(&b)
+
+			for k, v := range tt.args {
+				if k == "image" {
+					fw, err := w.CreateFormFile("image", v)
+					if err != nil {
+						t.Fatal(err)
+					}
+					fw.Write([]byte(v))
+				} else {
+					if err := w.WriteField(k, v); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			w.Close()
+
+			req := httptest.NewRequest("POST", "/items", &b)
+			req.Header.Set("Content-Type", w.FormDataContentType())
 
 			rr := httptest.NewRecorder()
 			h.AddItem(rr, req)
@@ -172,130 +214,160 @@ func TestAddItem(t *testing.T) {
 				return
 			}
 
-			for _, v := range tt.args {
-				if !strings.Contains(rr.Body.String(), v) {
-					t.Errorf("response body does not contain %s, got: %s", v, rr.Body.String())
-				}
+			var resp AddItemResponse
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("failed to decode response body: %v", err)
+			}
+
+			expectedMessage := fmt.Sprintf("item received: %s", tt.args["name"])
+			if resp.Message != expectedMessage {
+				t.Errorf("unexpected message, want %q, got %q", expectedMessage, resp.Message)
 			}
 		})
 	}
 }
 
-// STEP 6-4: uncomment this test
-// func TestAddItemE2e(t *testing.T) {
-// 	if testing.Short() {
-// 		t.Skip("skipping e2e test")
-// 	}
+func TestAddItemE2e(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
 
-// 	db, closers, err := setupDB(t)
-// 	if err != nil {
-// 		t.Fatalf("failed to set up database: %v", err)
-// 	}
-// 	t.Cleanup(func() {
-// 		for _, c := range closers {
-// 			c()
-// 		}
-// 	})
+	db, closers, err := setupDB(t)
+	if err != nil {
+		t.Fatalf("failed to set up database: %v", err)
+	}
+	t.Cleanup(func() {
+		for _, c := range closers {
+			c()
+		}
+	})
 
-// 	type wants struct {
-// 		code int
-// 	}
-// 	cases := map[string]struct {
-// 		args map[string]string
-// 		wants
-// 	}{
-// 		"ok: correctly inserted": {
-// 			args: map[string]string{
-// 				"name":     "used iPhone 16e",
-// 				"category": "phone",
-// 			},
-// 			wants: wants{
-// 				code: http.StatusOK,
-// 			},
-// 		},
-// 		"ng: failed to insert": {
-// 			args: map[string]string{
-// 				"name":     "",
-// 				"category": "phone",
-// 			},
-// 			wants: wants{
-// 				code: http.StatusBadRequest,
-// 			},
-// 		},
-// 	}
+	type wants struct {
+		code int
+	}
+	cases := map[string]struct {
+		args map[string]string
+		wants
+	}{
+		"ok: correctly inserted": {
+			args: map[string]string{
+				"name":     "used iPhone 16e",
+				"category": "phone",
+				"image":    "test.jpg",
+			},
+			wants: wants{
+				code: http.StatusOK,
+			},
+		},
+		"ng: failed to insert": {
+			args: map[string]string{
+				"name":     "",
+				"category": "phone",
+				"image":    "test.jpg",
+			},
+			wants: wants{
+				code: http.StatusBadRequest,
+			},
+		},
+	}
 
-// 	for name, tt := range cases {
-// 		t.Run(name, func(t *testing.T) {
-// 			h := &Handlers{itemRepo: &itemRepository{db: db}}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := &Handlers{
+				imgDirPath:   t.TempDir(),
+				itemRepo:     NewItemRepository(db),
+				categoryRepo: NewCategoryRepository(db),
+			}
 
-// 			values := url.Values{}
-// 			for k, v := range tt.args {
-// 				values.Set(k, v)
-// 			}
-// 			req := httptest.NewRequest("POST", "/items", strings.NewReader(values.Encode()))
-// 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			var b bytes.Buffer
+			w := multipart.NewWriter(&b)
 
-// 			rr := httptest.NewRecorder()
-// 			h.AddItem(rr, req)
+			for k, v := range tt.args {
+				if k == "image" {
+					fw, err := w.CreateFormFile("image", v)
+					if err != nil {
+						t.Fatal(err)
+					}
+					fw.Write([]byte("test image data"))
+				} else {
+					if err := w.WriteField(k, v); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			w.Close()
 
-// 			// check response
-// 			if tt.wants.code != rr.Code {
-// 				t.Errorf("expected status code %d, got %d", tt.wants.code, rr.Code)
-// 			}
-// 			if tt.wants.code >= 400 {
-// 				return
-// 			}
-// 			for _, v := range tt.args {
-// 				if !strings.Contains(rr.Body.String(), v) {
-// 					t.Errorf("response body does not contain %s, got: %s", v, rr.Body.String())
-// 				}
-// 			}
+			req := httptest.NewRequest("POST", "/items", &b)
+			req.Header.Set("Content-Type", w.FormDataContentType())
 
-// 			// STEP 6-4: check inserted data
-// 		})
-// 	}
-// }
+			rr := httptest.NewRecorder()
+			h.AddItem(rr, req)
 
-// func setupDB(t *testing.T) (db *sql.DB, closers []func(), e error) {
-// 	t.Helper()
+			if tt.wants.code != rr.Code {
+				t.Errorf("expected status code %d, got %d", tt.wants.code, rr.Code)
+			}
+			if tt.wants.code >= 400 {
+				return
+			}
 
-// 	defer func() {
-// 		if e != nil {
-// 			for _, c := range closers {
-// 				c()
-// 			}
-// 		}
-// 	}()
+			var resp AddItemResponse
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("failed to decode response body: %v", err)
+			}
 
-// 	// create a temporary file for e2e testing
-// 	f, err := os.CreateTemp(".", "*.sqlite3")
-// 	if err != nil {
-// 		return nil, nil, err
-// 	}
-// 	closers = append(closers, func() {
-// 		f.Close()
-// 		os.Remove(f.Name())
-// 	})
+			expectedMessage := fmt.Sprintf("item received: %s", tt.args["name"])
+			if resp.Message != expectedMessage {
+				t.Errorf("unexpected message, want %q, got %q", expectedMessage, resp.Message)
+			}
+		})
+	}
+}
 
-// 	// set up tables
-// 	db, err = sql.Open("sqlite3", f.Name())
-// 	if err != nil {
-// 		return nil, nil, err
-// 	}
-// 	closers = append(closers, func() {
-// 		db.Close()
-// 	})
+func setupDB(t *testing.T) (db *sql.DB, closers []func(), e error) {
+	t.Helper()
 
-// 	// TODO: replace it with real SQL statements.
-// 	cmd := `CREATE TABLE IF NOT EXISTS items (
-// 		id INTEGER PRIMARY KEY AUTOINCREMENT,
-// 		name VARCHAR(255),
-// 		category VARCHAR(255)
-// 	)`
-// 	_, err = db.Exec(cmd)
-// 	if err != nil {
-// 		return nil, nil, err
-// 	}
+	defer func() {
+		if e != nil {
+			for _, c := range closers {
+				c()
+			}
+		}
+	}()
 
-// 	return db, closers, nil
-// }
+	f, err := os.CreateTemp(".", "*.sqlite3")
+	if err != nil {
+		return nil, nil, err
+	}
+	closers = append(closers, func() {
+		f.Close()
+		os.Remove(f.Name())
+	})
+
+	db, err = sql.Open("sqlite3", f.Name())
+	if err != nil {
+		return nil, nil, err
+	}
+	closers = append(closers, func() {
+		db.Close()
+	})
+
+	// Create tables
+	schema := `
+	CREATE TABLE IF NOT EXISTS categories (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name VARCHAR(255) NOT NULL UNIQUE
+	);
+	CREATE TABLE IF NOT EXISTS items (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name VARCHAR(255),
+		category_id INTEGER,
+		image_name VARCHAR(255),
+		FOREIGN KEY (category_id) REFERENCES categories(id)
+	);
+	`
+	if _, err := db.Exec(schema); err != nil {
+		return nil, nil, err
+	}
+
+	return db, closers, nil
+}


### PR DESCRIPTION
## What
- Implemented Unit Test for AddItem Handler (TestAddItem)
  - Added MockCategoryRepository → The AddItem handler calls CategoryRepository.GetOrCreate(), so mock expectations were added.
  - Modified injector function signature → Changed to accept both MockItemRepository and MockCategoryRepository.
  - Set mock expectations for both Insert() and GetOrCreate() methods.

- Implemented End-to-End Test for AddItem (TestAddItemE2e)
  - Included categoryRepo initialization in Handlers.
  - Removed unnecessary checks in response body. → The response only contains "item received: {name}", so checking for category or image name was unnecessary.

- Implemented Unit Test for parseAddItemRequest (TestParseAddItemRequest)
  - Verified both valid and invalid request parsing.

- Implemented Unit Test for Hello Handler (TestHelloHandler)
  - Confirmed correct response from /hello endpoint.

- Improved setupDB() function
  - Ensured creation of required categories and items tables in the SQLite3 database for E2E tests.

## CHECKS :warning:

Please make sure you are aware of the following.

- [x] **The changes in this PR doesn't have private information
